### PR TITLE
Naprawione menu nawigacyjne

### DIFF
--- a/Web App/GB_Webpage/GB_Webpage/Views/Shared/_Layout.cshtml
+++ b/Web App/GB_Webpage/GB_Webpage/Views/Shared/_Layout.cshtml
@@ -14,8 +14,8 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
-            <div class="container-fluid">
+        <nav class="navbar navbar-expand-xl navbar-toggleable-xl border-bottom box-shadow mb-3">
+            <div class="container-fluid justify-content-center">
                 <a class="navbar-brand" asp-area="" asp-action="Index"><img src="~/images/logo_pl.png" alt="Logo" /></a>
 
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
@@ -23,7 +23,7 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
 
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                <div class="navbar-collapse collapse d-xl-inline-flex justify-content-between">
                     <ul id="menu-bar" class="navbar-nav flex-grow-1">
 
                         <li class="nav-item">


### PR DESCRIPTION
Menu nawigacyjne zostało naprawione. Teraz przy rozdzielczości mniejszej niż 1200px całe menu chowa się w 'hamburgera'. 

![image](https://user-images.githubusercontent.com/90453529/219673433-f47033d6-161e-480e-9824-7f5a50d6cbc9.png)