### PR TITLE
Błąd w zakładce o nas

### DIFF
--- a/Web App/GB_Webpage/GB_Webpage/Views/Home/Index.cshtml.css
+++ b/Web App/GB_Webpage/GB_Webpage/Views/Home/Index.cshtml.css
@@ -165,6 +165,15 @@ div.square-element {
 	}
 }
 
+@media only screen and (min-width: 1669px) {
+
+	p.box {
+		width: 20%;
+	}
+
+	
+}
+
 @media only screen and (min-width: 992px) and (max-width: 1199px) {
 
 	p.box {


### PR DESCRIPTION
Naprawiono rozjeżdżający się tekst w szarym kwadracie znajdującym się w zakładce 'o nas'. Ten tekst dopasowany jest do wszystkich języków. 

![image](https://user-images.githubusercontent.com/90453529/220882896-8d51c80d-7e94-42c8-99e9-c7df6588581d.png)
![image](https://user-images.githubusercontent.com/90453529/220882920-aee80e47-79ea-46ec-bd6d-0da1f5e22cfa.png)
![image](https://user-images.githubusercontent.com/90453529/220882943-fb67f160-8c88-489d-9e88-ebe3d8fd171f.png)
![image](https://user-images.githubusercontent.com/90453529/220882970-2d071bb7-906b-4026-9bda-d9a091059634.png)
